### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/TODOs.md
+++ b/TODOs.md
@@ -28,7 +28,7 @@
 - [x] Activate currently open calendar tab instead of creating a new one
 - [ ] Import/export for configuration (esp. presets)
 - [ ] Reordering presets manually
-- [ ] Keyboard shortcuts
+- [x] Keyboard shortcuts
 - [ ] Support for multiple Google accounts per browser profile
 - [ ] Save currently active calendars as new preset
 - [ ] Premium: Support for teams (share presets across your organisation, integrate with directory service etc.)

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,17 @@ async function refreshAllCalendars() {
     }
 }
 
+function initShortcuts(presetIds) {
+    window.addEventListener('keydown', (ev) => {
+        if (ev.ctrlKey && ev.altKey) {
+            const keyNum = Number.parseInt(ev.key)
+            const presetId = presetIds[keyNum - 1]
+            console.log(keyNum, presetId)
+            presetId != undefined && focusCalendars(presetId)
+        }
+    })
+}
+
 async function initCalendars(presets) {
     await sleep(4000)
     let { myCalendarsFromDiv, otherCalendarsFromDiv } =
@@ -50,7 +61,7 @@ async function initCalendars(presets) {
     if (typeof presets === 'undefined' || Object.keys(presets).length == 0) {
         debugMessage = 'No presets found, initialising with defaults'
         console.log(debugMessage)
-        let presets = {}
+        presets = {}
         presets[generateId()] = {
             name: 'Preset 1',
             calendars: namesFromCalendarJQObjects(myCalendarsFromDiv),
@@ -63,6 +74,10 @@ async function initCalendars(presets) {
         }
         storePresets(presets)
     }
+
+    const presetIds = Object.keys(presets)
+    presetIds.sort((a, b) => presets[a].orderValue - presets[b].orderValue)
+    initShortcuts(presetIds)
 
     debugMessage =
         'Init Calendars done with ' + allCalendars.length + ' calendars'

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,29 +1,6 @@
 'use strict'
 
 
-async function focusCalendars(presetId) {
-    await refreshAllCalendars()
-    getPresetsFromStorage(
-        function (presets) {
-            const calendarJQObjects = calendarJQObjectsFromNames(
-                presets[presetId].calendars,
-                allCalendars
-            )
-            const calendarsToHide = [...allCalendars].filter(
-                (x) => !calendarJQObjects.includes(x)
-            )
-            setStateOnCalendars(calendarsToHide, false)
-            setStateOnCalendars(calendarJQObjects, true)
-        },
-        function (err) {
-            const errorMessage =
-                "Couldn't load presets from storage to focus: " + err
-            console.log(errorMessage)
-        }
-    )
-}
-
-
 async function hideAllCalendars() {
     await refreshAllCalendars()
     setStateOnCalendars(allCalendars, false)

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,31 @@ async function getDrawerDelayFromStorageAsync() {
     return promise
 }
 
+// Shared actions
+
+/** Can only be called in the injected context */
+async function focusCalendars(presetId) {
+    await refreshAllCalendars()
+    getPresetsFromStorage(
+        function (presets) {
+            const calendarJQObjects = calendarJQObjectsFromNames(
+                presets[presetId].calendars,
+                allCalendars
+            )
+            const calendarsToHide = [...allCalendars].filter(
+                (x) => !calendarJQObjects.includes(x)
+            )
+            setStateOnCalendars(calendarsToHide, false)
+            setStateOnCalendars(calendarJQObjects, true)
+        },
+        function (err) {
+            const errorMessage =
+                "Couldn't load presets from storage to focus: " + err
+            console.log(errorMessage)
+        }
+    )
+}
+
 // Object helpers
 
 const calendarNameStringsToStrip = ['Loading...', //g, //g]


### PR DESCRIPTION
On the Google calendar page, press `ctrl` + `alt` + (index of the preset, starting at 1).